### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,31 +5,31 @@ jobs:
     deploy:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v4
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
           with:
-            python-version: '3.9'
-        - uses: actions/setup-node@v1
+            python-version: '3.14'
+        - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
           with:
-            node-version: 16
+            node-version: 23
         - run: |
             cd brianextension
             pip install --target bundled/libs pygls
             npm ci
         - name: Publish to Open VSX Registry
           id: publishToOpenVSX
-          uses: HaaLeo/publish-vscode-extension@v1
+          uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db  # v2
           with:
             pat: ${{ secrets.OPEN_VSX_TOKEN }}
             packagePath: brianextension
         - name: Publish to Visual Studio Marketplace
-          uses: HaaLeo/publish-vscode-extension@v1
+          uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db  # v2
           with:
             pat:  ${{ secrets.VS_MARKETPLACE_TOKEN }}
             registryUrl: https://marketplace.visualstudio.com
             extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
         - name: Upload package file as artifact
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
           with:
             name: package
             path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}


### PR DESCRIPTION
The GitHub actions were very outdated and some of them deprecated, this PR replaces them with recent versions and configures dependabot to keep them up-to-date in the future.